### PR TITLE
Get codes

### DIFF
--- a/coconnect/tools/omop_db_inspect.py
+++ b/coconnect/tools/omop_db_inspect.py
@@ -58,6 +58,35 @@ class OMOPDetails():
         and puts the contents into two pandas dataframes.
         2) Checks if the conceptID is standard/non-standard
     """
+    
+    def lookup_code(self, concept_code):
+        
+        print ("Working on... ", concept_code)
+        
+        #From OMOP db get concept relationship
+        select_from_code = r'''
+        SELECT *
+        FROM public.concept
+        WHERE concept_code = '%s'
+        '''
+        select_from_concept_relationship = r'''
+        SELECT *
+        FROM public.concept_relationship
+        WHERE concept_id_1 = ('%s')
+        '''
+    
+        #retrieve the concept code mapping
+        df_code = pd.read_sql(select_from_code%(concept_code),self.ngin)
+        print(df_code)
+        
+        maps = []
+        for index, row in df_code.iterrows():
+            print(row['concept_id'])
+            maps.append(pd.read_sql(select_from_concept_relationship%(row['concept_id']),self.ngin))
+        
+        print(maps)
+        
+    
     def get_rules(self,source_concept_ids):
         print ("working on",source_concept_ids)
         #From OMOP db get concept relationship
@@ -96,8 +125,6 @@ class OMOPDetails():
                            ]
                            ,axis=1)
                        
-        print(df_concept)
-
         #retrieve a relationship lookup
         df_relationship = pd.read_sql(
             select_from_concept_relationship%(_ids),self.ngin)\
@@ -106,8 +133,6 @@ class OMOPDetails():
                                  "valid_end_date",
                                  "invalid_reason"],axis=1)
                             
-        print(df_relationship)
-
         #when the relationship=Maps to -> Non-standard to standard mapping
         #we don't need to check for Concept same_as_to
         relationship_ids = [

--- a/coconnect/tools/omop_db_inspect.py
+++ b/coconnect/tools/omop_db_inspect.py
@@ -136,14 +136,17 @@ class OMOPDetails():
                 axis=1
             )
             relationship_ids = ['Maps to']
-            x = x[x['relationship_id'].isin(relationship_ids)]
+            x = x[x['relationship_id']
+                  .isin(relationship_ids)]
             maps.append(x)
             
         # Concat maps list into single pandas df
         df_maps = pd.concat(maps,ignore_index=True)
         
         # Join the first df_codes dataframe to the mapped codes for return
-        joined_df = df_code.merge(df_maps, left_on='concept_id', right_on='concept_id_1')
+        joined_df = df_code.merge(
+            df_maps, left_on='concept_id', right_on='concept_id_1'
+            )
         
         return joined_df
         

--- a/coconnect/tools/omop_db_inspect.py
+++ b/coconnect/tools/omop_db_inspect.py
@@ -105,7 +105,7 @@ class OMOPDetails():
     
     def lookup_code(self, concept_code):
         
-        print ("Working on... ", concept_code)
+        print ("Working on...", concept_code)
         
         # SQL code for looking up codes and conceptIDs
         select_from_code = r'''
@@ -123,7 +123,6 @@ class OMOPDetails():
         df_code = pd.read_sql(
             select_from_code%(concept_code),self.ngin
             )
-        # print('CONCEPT CODES >>>>> \n', df_code)
         
         # Look up each concept *code* for a corresponding conceptID
         # Returns only rows where relationship_id == 'Maps to'
@@ -140,10 +139,12 @@ class OMOPDetails():
             x = x[x['relationship_id'].isin(relationship_ids)]
             maps.append(x)
             
+        # Concat maps list into single pandas df
         df_maps = pd.concat(maps,ignore_index=True)
+        
+        # Join the first df_codes dataframe to the mapped codes for return
         joined_df = df_code.merge(df_maps, left_on='concept_id', right_on='concept_id_1')
         
-        # print('MAPS >>>>> \n', joined_df)
         return joined_df
         
     

--- a/coconnect/tools/omop_db_inspect.py
+++ b/coconnect/tools/omop_db_inspect.py
@@ -95,6 +95,8 @@ class OMOPDetails():
                                "invalid_reason"
                            ]
                            ,axis=1)
+                       
+        print(df_concept)
 
         #retrieve a relationship lookup
         df_relationship = pd.read_sql(
@@ -103,6 +105,8 @@ class OMOPDetails():
                                 ["valid_start_date",
                                  "valid_end_date",
                                  "invalid_reason"],axis=1)
+                            
+        print(df_relationship)
 
         #when the relationship=Maps to -> Non-standard to standard mapping
         #we don't need to check for Concept same_as_to


### PR DESCRIPTION
This PR creates a new method called get_codes()
The purpose of the method is to convert singular concept _codes_ into OMOP-standard conceptIDs.