### PR TITLE
Co connect tools windowssupport

### DIFF
--- a/coconnect/tools/__init__.py
+++ b/coconnect/tools/__init__.py
@@ -13,6 +13,7 @@ from .file_helpers import (
     load_json,
     load_csv,
     get_file_map_from_dir,
+    get_file_map_from_dir_windows,
     get_mapped_fields_from_rules
 )
 

--- a/coconnect/tools/file_helpers.py
+++ b/coconnect/tools/file_helpers.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import json
 import pandas as pd
@@ -64,8 +65,10 @@ def load_json(f_in):
     return data
 
 
-def load_csv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",rules=None):
-
+def load_csv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",rules=None):    
+    if sys.platform =="win32":
+        _map=get_file_map_from_dir_windows(_map)
+        
     if rules is not None:
         rules = load_json(rules)
         source_map = get_mapped_fields_from_rules(rules)
@@ -112,6 +115,13 @@ def load_csv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",r
 
     return retval
 
+def get_file_map_from_dir_windows(_dir):    
+    filePath = (str(_dir).replace(os.sep,'/')).replace('//','/').strip("[]''")            
+    _map={}
+    for fname in glob.glob(filePath):
+        key = os.path.basename(fname)
+        _map[key] = fname    
+    return _map
 
 def get_file_map_from_dir(_dir):
     if not os.path.isdir(_dir):

--- a/coconnect/tools/file_helpers.py
+++ b/coconnect/tools/file_helpers.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import glob
 import json
 import pandas as pd
@@ -66,9 +65,7 @@ def load_json(f_in):
 
 
 def load_csv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",rules=None):    
-    if sys.platform =="win32":
-        _map=get_file_map_from_dir_windows(_map)
-        
+           
     if rules is not None:
         rules = load_json(rules)
         source_map = get_mapped_fields_from_rules(rules)

--- a/scripts/etlcdm.py
+++ b/scripts/etlcdm.py
@@ -21,7 +21,8 @@ from coconnect.cdm import (
 from coconnect.tools import (
     load_csv,
     load_json,
-    apply_rules
+    apply_rules,
+    get_file_map_from_dir_windows
 )
 
 
@@ -55,7 +56,7 @@ def main():
 
     if sys.platform =="win32":
        inputs = load_csv(
-        _map=args.inputs,
+        _map=get_file_map_from_dir_windows(args.inputs),
         chunksize=args.number_of_rows_per_chunk,
         nrows=args.number_of_rows_to_process        
         )     

--- a/scripts/etlcdm.py
+++ b/scripts/etlcdm.py
@@ -53,14 +53,22 @@ def main():
 
     config = load_json(args.rules)
 
-    inputs = load_csv(
+    if sys.platform =="win32":
+       inputs = load_csv(
+        _map=args.inputs,
+        chunksize=args.number_of_rows_per_chunk,
+        nrows=args.number_of_rows_to_process        
+        )     
+       
+    else:
+       inputs = load_csv(
         {
             os.path.basename(x):x
             for x in args.inputs
         },
         chunksize=args.number_of_rows_per_chunk,
         nrows=args.number_of_rows_to_process
-    )
+        )
 
     name = config['metadata']['dataset']
 

--- a/scripts/etlcdm.py
+++ b/scripts/etlcdm.py
@@ -55,21 +55,20 @@ def main():
     config = load_json(args.rules)
 
     if sys.platform =="win32":
-       inputs = load_csv(
-        _map=get_file_map_from_dir_windows(args.inputs),
-        chunksize=args.number_of_rows_per_chunk,
-        nrows=args.number_of_rows_to_process        
-        )     
-       
+        inputs = load_csv(
+         _map=get_file_map_from_dir_windows(args.inputs),
+         chunksize=args.number_of_rows_per_chunk,
+         nrows=args.number_of_rows_to_process        
+         )
     else:
-       inputs = load_csv(
-        {
-            os.path.basename(x):x
-            for x in args.inputs
-        },
-        chunksize=args.number_of_rows_per_chunk,
-        nrows=args.number_of_rows_to_process
-        )
+        inputs = load_csv(
+         {
+             os.path.basename(x):x
+             for x in args.inputs
+         },
+         chunksize=args.number_of_rows_per_chunk,
+         nrows=args.number_of_rows_to_process
+         )
 
     name = config['metadata']['dataset']
 


### PR DESCRIPTION
etlcdm.py now works for windows. For example:

d:>etlcdm.py -i D:/co-connect-tools/coconnect/data/test/inputs/*.csv --rules D:/co-connect-tools/coconnect/data/test/rules/rules_14June2021.json -o D:/co-connect-tools/coconnect/data/test/  