### PR TITLE
Remove/etlcdm functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install co-connect-tools
         run:  pip3 install -e .
       - run: coconnect --help
-  unit_test_1:
+  unit_test_py_config:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -47,7 +47,7 @@ jobs:
           name: outputs
           path: output_data
           retention-days: 1
-  unit_test_2:
+  unit_test_json_config:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -67,7 +67,7 @@ jobs:
         run:  pip3 install -e .
       - run: |
           COCONNECT_DATA_FOLDER=$(coconnect info data_folder)
-          etlcdm.py -i $COCONNECT_DATA_FOLDER/test/inputs/*.csv --rules $COCONNECT_DATA_FOLDER/test/rules/rules_14June2021.json -o tests/
+          coconnect map run --name Lion --rules $COCONNECT_DATA_FOLDER/test/rules/rules_14June2021.json -o tests/ $COCONNECT_DATA_FOLDER/test/inputs/*.csv 
       - run: |
           for filename in tests/*.csv; do
                fname=${filename##*/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run:  pip3 install -e .
       - run: |
           COCONNECT_DATA_FOLDER=$(coconnect info data_folder)
-          coconnect map run --rules $COCONNECT_DATA_FOLDER/test/rules/rules_14June2021.json -o tests/ $COCONNECT_DATA_FOLDER/test/inputs/*.csv 
+          coconnect map run --rules $COCONNECT_DATA_FOLDER/test/rules/rules_14June2021.json --output-folder tests/ $COCONNECT_DATA_FOLDER/test/inputs/*.csv 
       - run: |
           for filename in tests/*.csv; do
                fname=${filename##*/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run:  pip3 install -e .
       - run: |
           COCONNECT_DATA_FOLDER=$(coconnect info data_folder)
-          coconnect map run --name Lion --rules $COCONNECT_DATA_FOLDER/test/rules/rules_14June2021.json -o tests/ $COCONNECT_DATA_FOLDER/test/inputs/*.csv 
+          coconnect map run --rules $COCONNECT_DATA_FOLDER/test/rules/rules_14June2021.json -o tests/ $COCONNECT_DATA_FOLDER/test/inputs/*.csv 
       - run: |
           for filename in tests/*.csv; do
                fname=${filename##*/}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,31 @@
+# Helper Scripts
+
+This folder contains scripts showing examples of how you can implement your own script to use the python CommonDataModel to build a model and execute a transformation of a dataset into the OHDSI CDM.
+
+## etlcdm.py
+
+The help message for this script displays:
+```
+usage: etlcdm.py [-h] --rules RULES --out-dir OUT_DIR --inputs INPUTS [INPUTS ...] [-nc NUMBER_OF_ROWS_PER_CHUNK]
+                 [-np NUMBER_OF_ROWS_TO_PROCESS] [--use-profiler]
+
+ETL-CDM: transform a dataset into a CommonDataModel.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --rules RULES         input .json file
+  --out-dir OUT_DIR, -o OUT_DIR
+                        name of the output folder
+  --inputs INPUTS [INPUTS ...], -i INPUTS [INPUTS ...]
+                        input csv files
+  -nc NUMBER_OF_ROWS_PER_CHUNK, --number-of-rows-per-chunk NUMBER_OF_ROWS_PER_CHUNK
+                        choose to chunk running the data into nrows
+  -np NUMBER_OF_ROWS_TO_PROCESS, --number-of-rows-to-process NUMBER_OF_ROWS_TO_PROCESS
+                        the total number of rows to process
+  --use-profiler        turn on saving statistics for profiling CPU and memory usage
+```
+
+For example, to execute this script run:
+```bash
+etlcdm.py -i <input file 1> <input file 2> .... <input file N>  --rules <json rules>  -o <location of output folder>
+```

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/CO-CONNECT/co-connect-tools",
-    scripts = ['scripts/etlcdm.py'],
     entry_points = {
         'console_scripts':[
             'coconnect=coconnect.cli.cli:coconnect',


### PR DESCRIPTION
* removes etlcdm.py from setup.py, which would install the script
* updates the CI to not run the unit test for etlcdm.py but run it for `coconnect map run` 
* doesn't actually delete the script, so keeping it in the script folder and added a small readme, just incase someone stumbles upon it in the future and is interested in using our pythonic CDM to perform an ETL 