### PR TITLE
adding functionality to apply operations on data

### DIFF
--- a/coconnect/cdm/__init__.py
+++ b/coconnect/cdm/__init__.py
@@ -20,5 +20,6 @@ from .decorators import (
     define_measurement,
     define_observation,
     define_drug_exposure,
-    load_file
+    load_file,
+    from_table
 )

--- a/coconnect/cdm/__init__.py
+++ b/coconnect/cdm/__init__.py
@@ -1,7 +1,7 @@
 from .model import CommonDataModel
 from .operations import OperationTools
 
-from .objects import get_cdm_class
+from .objects import get_cdm_class, get_cdm_decorator
 
 #can we make these imports dynamic?
 from .objects import (
@@ -19,5 +19,6 @@ from .decorators import (
     define_visit_occurrence,
     define_measurement,
     define_observation,
-    define_drug_exposure
+    define_drug_exposure,
+    load_file
 )

--- a/coconnect/cdm/decorators.py
+++ b/coconnect/cdm/decorators.py
@@ -1,4 +1,12 @@
-from .objects import Person, ConditionOccurrence, VisitOccurrence, Measurement, Observation, DrugExposure
+from .objects import (
+    Person,
+    ConditionOccurrence,
+    VisitOccurrence,
+    Measurement,
+    Observation,
+    DrugExposure
+)
+
 
 def load_file(fname):
     def func(self):
@@ -6,6 +14,18 @@ def load_file(fname):
             self[colname].series = self.inputs[fname][colname]
     func.__name__ = fname
     return func
+
+
+def from_table(table):
+    def decorator(defs):
+        def wrapper(obj):
+            df = obj.inputs[table]
+            for colname in df.columns:
+                obj[colname].series = df[colname]
+            return defs
+        wrapper.__name__ = defs.__name__
+        return wrapper
+    return decorator
 
 def define_person(defs):
     p = Person()

--- a/coconnect/cdm/decorators.py
+++ b/coconnect/cdm/decorators.py
@@ -23,10 +23,8 @@ def from_table(obj,table):
     return obj
 
 
-def define_person(input=None):
-    print ("define person")
+def define_person_v2(input=None):
     def decorator(defs):
-        print ("in decorator")
         def wrapper(obj):
             if input is not None:
                 obj = from_table(obj,input)
@@ -36,8 +34,13 @@ def define_person(input=None):
         p.define = wrapper 
         p.set_name(defs.__name__)
         return p
-    print (decorator)
     return decorator
+
+def define_person(defs):
+    c = Person()
+    c.define = defs
+    c.set_name(defs.__name__)
+    return c
 
 def define_condition_occurrence(defs):
     c = ConditionOccurrence()

--- a/coconnect/cdm/decorators.py
+++ b/coconnect/cdm/decorators.py
@@ -1,5 +1,11 @@
 from .objects import Person, ConditionOccurrence, VisitOccurrence, Measurement, Observation, DrugExposure
-    
+
+def load_file(fname):
+    def func(self):
+        for colname in self.inputs[fname]:
+            self[colname].series = self.inputs[fname][colname]
+    return func
+
 def define_person(defs):
     p = Person()
     p.define = defs

--- a/coconnect/cdm/decorators.py
+++ b/coconnect/cdm/decorators.py
@@ -16,22 +16,28 @@ def load_file(fname):
     return func
 
 
-def from_table(table):
-    def decorator(defs):
-        def wrapper(obj):
-            df = obj.inputs[table]
-            for colname in df.columns:
-                obj[colname].series = df[colname]
-            return defs
-        wrapper.__name__ = defs.__name__
-        return wrapper
-    return decorator
+def from_table(obj,table):
+    df = obj.inputs[table]
+    for colname in df.columns:
+        obj[colname].series = df[colname]
+    return obj
 
-def define_person(defs):
-    p = Person()
-    p.define = defs
-    p.set_name(defs.__name__)
-    return p
+
+def define_person(input=None):
+    print ("define person")
+    def decorator(defs):
+        print ("in decorator")
+        def wrapper(obj):
+            if input is not None:
+                obj = from_table(obj,input)
+            defs(obj)
+
+        p = Person()
+        p.define = wrapper 
+        p.set_name(defs.__name__)
+        return p
+    print (decorator)
+    return decorator
 
 def define_condition_occurrence(defs):
     c = ConditionOccurrence()

--- a/coconnect/cdm/decorators.py
+++ b/coconnect/cdm/decorators.py
@@ -4,6 +4,7 @@ def load_file(fname):
     def func(self):
         for colname in self.inputs[fname]:
             self[colname].series = self.inputs[fname][colname]
+    func.__name__ = fname
     return func
 
 def define_person(defs):

--- a/coconnect/cdm/model.py
+++ b/coconnect/cdm/model.py
@@ -47,6 +47,7 @@ class CommonDataModel:
                  output_database=None,
                  indexing_conf=None,
                  person_id_map=None,
+                 save_files=True,
                  inputs=None,
                  use_profiler=False,
                  format_level=None,
@@ -458,9 +459,10 @@ class CommonDataModel:
             mode = 'w'
             if i>0:
                 mode='a'
-                
-            self.save_dataframes(mode=mode)
-            self.save_logs(extra=f'_slice_{i}')
+
+            if self.save_files:
+                self.save_dataframes(mode=mode)
+                self.save_logs(extra=f'_slice_{i}')
 
             i+=1
             
@@ -481,8 +483,9 @@ class CommonDataModel:
             self[destination_table] = self.process_table(destination_table)
             self.logger.info(f'finalised {destination_table}')
 
-        self.save_dataframes()
-        self.save_logs()
+        if self.save_files:
+            self.save_dataframes()
+            self.save_logs()
                 
             
     def process_table(self,destination_table):

--- a/coconnect/cdm/model.py
+++ b/coconnect/cdm/model.py
@@ -13,8 +13,8 @@ from coconnect.tools.file_helpers import InputData
 
 from coconnect import __version__ as cc_version
 from .objects import DestinationTable, FormatterLevel
-from .objects import get_cdm_class
-from .decorators import *
+from .objects import get_cdm_class, get_cdm_decorator
+from .decorators import load_file
 
 class NoInputFiles(Exception):
     pass
@@ -33,17 +33,10 @@ class CommonDataModel:
 
     @classmethod
     def load(cls,inputs):
-        def func(self):
-            for colname in self.inputs['person.tsv']:
-                self[colname].series = self.inputs['person.tsv'][colname]
-                print ('made',colname)
-        
         cdm = cls(inputs=inputs)
         for fname in inputs.keys():
             destination_table,_ = os.path.splitext(fname)
-            if destination_table == 'person':
-                obj = define_person(func)#get_cdm_class(destination_table)()
-                print (obj)
+            obj = get_cdm_decorator(destination_table)(load_file(fname))
             cdm.add(obj)
         return cdm
     

--- a/coconnect/cdm/model.py
+++ b/coconnect/cdm/model.py
@@ -32,14 +32,16 @@ class CommonDataModel:
     """
 
     @classmethod
-    def load(cls,inputs):
-        cdm = cls(inputs=inputs)
+    def load(cls,**kwargs):
+        cdm = cls(**kwargs)
+        inputs = kwargs['inputs']
         for fname in inputs.keys():
             destination_table,_ = os.path.splitext(fname)
             obj = get_cdm_decorator(destination_table)(load_file(fname))
             cdm.add(obj)
         return cdm
     
+
     def __init__(self, name=None, 
                  output_folder=f"output_data{os.path.sep}",
                  output_database=None,

--- a/coconnect/cdm/model.py
+++ b/coconnect/cdm/model.py
@@ -114,10 +114,10 @@ class CommonDataModel:
         elif isinstance(inputs,InputData):
             self.logger.info("Running with an InputData object")
 
-        if hasattr(self,'inputs') and inputs is not None:
-            self.logger.waring("overwriting inputs")
-            
-        self.inputs = inputs
+        if inputs is not None:
+            if hasattr(self,'inputs'):
+                self.logger.warning("overwriting inputs")
+            self.inputs = inputs
             
         #register opereation tools
         self.tools = OperationTools()
@@ -410,7 +410,7 @@ class CommonDataModel:
         """
         return self.__objects
 
-    def process(self,save_files=True):
+    def process(self):
         """
         Main functionality of the CommonDataModel class
         When executed, this function determines the order in which to process the CDM tables

--- a/coconnect/cdm/objects/__init__.py
+++ b/coconnect/cdm/objects/__init__.py
@@ -5,6 +5,8 @@ from .measurement import Measurement
 from .observation import Observation
 from .drug_exposure import DrugExposure
 
+import coconnect.cdm.decorators as decorators
+
 import sys
 this = sys.modules[__name__]
 
@@ -13,10 +15,21 @@ __cdm_objects = [
     for name in dir(this)
     if isinstance(getattr(this,name), type)
 ]
+
+
+__cdm_decorator_map = {
+    name.lstrip("define_"):getattr(decorators,name)
+    for name in dir(decorators)
+    if 'define' in name
+}
+
 __cdm_object_map = {
     x.name: x
     for x in __cdm_objects
 }
+
+def get_cdm_decorator(key):
+    return __cdm_decorator_map[key]
 
 def get_cdm_class(key):
     return __cdm_object_map[key]

--- a/coconnect/cdm/objects/__init__.py
+++ b/coconnect/cdm/objects/__init__.py
@@ -5,7 +5,7 @@ from .measurement import Measurement
 from .observation import Observation
 from .drug_exposure import DrugExposure
 
-import coconnect.cdm.decorators as decorators
+from .. import decorators 
 
 import sys
 this = sys.modules[__name__]
@@ -35,3 +35,4 @@ def get_cdm_class(key):
     return __cdm_object_map[key]
 
 from .common import DestinationTable, DataFormatter, FormatterLevel
+

--- a/coconnect/cdm/objects/common.py
+++ b/coconnect/cdm/objects/common.py
@@ -138,6 +138,18 @@ class DestinationTable(object):
     """
     Common object that all CDM objects (tables) inherit from.
     """
+
+    @classmethod
+    def from_df(cls,df):
+        obj = cls()
+        obj.__df = df
+        for colname in df.columns:
+            obj[colname].series = df[colname]
+        return obj
+
+    def __len__(self):
+        return len(self.__df)
+
     def __init__(self,_type,_version='v5_3_1'):
         """
         Initialise the CDM DestinationTable Object class

--- a/coconnect/cdm/objects/common.py
+++ b/coconnect/cdm/objects/common.py
@@ -139,13 +139,6 @@ class DestinationTable(object):
     Common object that all CDM objects (tables) inherit from.
     """
 
-    #@classmethod
-    #def from_file(cls,df):
-    #    obj = cls()
-    #    for colname in df.columns:
-    #        obj[colname].series = df[colname]
-    #    return obj
-
     def __len__(self):
         return len(self.__df)
 

--- a/coconnect/cdm/objects/common.py
+++ b/coconnect/cdm/objects/common.py
@@ -167,6 +167,8 @@ class DestinationTable(object):
         self.format_level = FormatterLevel(1)
         self.fields = self.get_field_names()
 
+        self.do_formatting = True
+
         if len(self.fields) == 0:
             raise Exception("something misconfigured - cannot find any DataTypes for {self.name}")
 
@@ -339,7 +341,8 @@ class DestinationTable(object):
         #simply order the columns 
         df = df[self.fields]
 
-        df = self.format(df)
+        if self.do_formatting:
+            df = self.format(df)
         df = self.finalise(df)
                 
         #register the df

--- a/coconnect/cdm/objects/common.py
+++ b/coconnect/cdm/objects/common.py
@@ -139,13 +139,12 @@ class DestinationTable(object):
     Common object that all CDM objects (tables) inherit from.
     """
 
-    @classmethod
-    def from_df(cls,df):
-        obj = cls()
-        obj.__df = df
-        for colname in df.columns:
-            obj[colname].series = df[colname]
-        return obj
+    #@classmethod
+    #def from_file(cls,df):
+    #    obj = cls()
+    #    for colname in df.columns:
+    #        obj[colname].series = df[colname]
+    #    return obj
 
     def __len__(self):
         return len(self.__df)

--- a/coconnect/cdm/operations.py
+++ b/coconnect/cdm/operations.py
@@ -3,11 +3,11 @@ import datetime
 
 class OperationTools:
 
-    get_datetime = lambda self,df : pd.to_datetime(df).dt.strftime('%Y-%m-%d %H:%M:%S')
+    get_datetime = lambda self,df : pd.to_datetime(df).dt.strftime('%Y-%m-%dT%H:%M:%S.%f')
     get_date = lambda self,df : pd.to_datetime(df).dt.strftime('%Y-%m-%d')
-    get_year = lambda self,df : pd.to_datetime(df).dt.year.astype('Int64')
-    get_month = lambda self,df : pd.to_datetime(df).dt.month.astype('Int64')
-    get_day = lambda self,df : pd.to_datetime(df).dt.day.astype('Int64')
+    get_year = lambda self,df : pd.to_datetime(df).dt.year
+    get_month = lambda self,df : pd.to_datetime(df).dt.month
+    get_day = lambda self,df : pd.to_datetime(df).dt.day
 
     def keys(self):
         return [ key for key in dir(self) if key.startswith('get') ]

--- a/coconnect/cdm/operations.py
+++ b/coconnect/cdm/operations.py
@@ -3,11 +3,11 @@ import datetime
 
 class OperationTools:
 
-    get_datetime = lambda self,df : pd.to_datetime(df).dt.strftime('%Y-%m-%dT%H:%M:%S.%f')
-    get_date = lambda self,df : pd.to_datetime(df).dt.strftime('%Y-%m-%d')
-    get_year = lambda self,df : pd.to_datetime(df).dt.year
-    get_month = lambda self,df : pd.to_datetime(df).dt.month
-    get_day = lambda self,df : pd.to_datetime(df).dt.day
+    get_datetime = lambda self,df : pd.to_datetime(df,errors='coerce').dt.strftime('%Y-%m-%dT%H:%M:%S.%f')
+    get_date = lambda self,df : pd.to_datetime(df,errors='coerce').dt.strftime('%Y-%m-%d')
+    get_year = lambda self,df : pd.to_datetime(df,errors='coerce').dt.year
+    get_month = lambda self,df : pd.to_datetime(df,errors='coerce').dt.month
+    get_day = lambda self,df : pd.to_datetime(df,errors='coerce').dt.day
 
     def keys(self):
         return [ key for key in dir(self) if key.startswith('get') ]

--- a/coconnect/cdm/operations.py
+++ b/coconnect/cdm/operations.py
@@ -9,6 +9,9 @@ class OperationTools:
     get_month = lambda self,df : pd.to_datetime(df).dt.month.astype('Int64')
     get_day = lambda self,df : pd.to_datetime(df).dt.day.astype('Int64')
 
+    def keys(self):
+        return [ key for key in dir(self) if key.startswith('get') ]
+    
     def get_datetime_from_age(self,df,norm=None):
         if norm is None:
             #set normalisation to middle of 2020

--- a/coconnect/cdm/operations.py
+++ b/coconnect/cdm/operations.py
@@ -3,7 +3,7 @@ import datetime
 
 class OperationTools:
 
-    get_datetime = lambda self,df : pd.to_datetime(df,errors='coerce').dt.strftime('%Y-%m-%dT%H:%M:%S.%f')
+    get_datetime = lambda self,df : pd.to_datetime(df,errors='coerce').dt.strftime('%Y-%m-%d %H:%M:%S.%f')
     get_date = lambda self,df : pd.to_datetime(df,errors='coerce').dt.strftime('%Y-%m-%d')
     get_year = lambda self,df : pd.to_datetime(df,errors='coerce').dt.year
     get_month = lambda self,df : pd.to_datetime(df,errors='coerce').dt.month

--- a/coconnect/cli/subcommands/map.py
+++ b/coconnect/cli/subcommands/map.py
@@ -95,10 +95,8 @@ def format(inputs):
         inputs = tools.load_tsv(inputs)
 
 
-    cdm = coconnect.cdm.CommonDataModel()
-    print (cdm)
-
-    
+    cdm = coconnect.cdm.CommonDataModel.load(inputs=inputs)
+    cdm.process()
         
 @click.command()
 @click.option("--input",

--- a/coconnect/cli/subcommands/map.py
+++ b/coconnect/cli/subcommands/map.py
@@ -73,11 +73,67 @@ def test(ctx):
 
 
 @click.command()
+@click.option("--config","-c",required=True,type=str)
+@click.option("--number-of-rows-per-chunk","--nc",default=1e5,type=int)
+@click.option("--output-folder","-o",required=True,type=str)
+@click.argument("inputs",nargs=-1,required=True)
+def transform(inputs,config,number_of_rows_per_chunk,output_folder):
+
+    logger = tools.logger.Logger("transform")
+    
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+    
+    if os.path.isfile(config):
+        config = json.load(open(config))
+    else:
+        config = json.loads(config)
+
+    logger.info(json.dumps(config,indent=6))
+        
+    inputs = {
+        os.path.basename(x):x
+        for x in inputs
+    }
+    input_data = tools.load_csv(inputs,chunksize=number_of_rows_per_chunk)
+
+    operation_tools = coconnect.cdm.OperationTools()
+
+    header=True
+    mode='w'
+
+    i = 0 
+    while True:
+        if i > 0:
+            mode = 'a'
+            header=False
+        i+=1
+        for fname,rules in config.items():
+            logger.info(f"Working on {fname}") 
+            df = input_data[fname]
+            for colname,operations in rules.items():
+                series = df[colname]
+                for operation in operations:
+                    logger.info(f".. transforming '{colname}' with operation '{operation}'")
+                    fn_operation = operation_tools[operation]
+                    series = fn_operation(series)
+                df[colname] = series
+            fout = f"{output_folder}/{fname}"
+            df.to_csv(fout,header=header,mode=mode,index=False)
+
+        try:
+            input_data.next()
+        except StopIteration:
+            break
+
+@click.command()
 @click.option("--number-of-rows-per-chunk","--nc",default=1e5,type=int)
 @click.option("--output-folder","-o",required=True,type=str)
 @click.argument("inputs",nargs=-1,required=True)
 def format(inputs,number_of_rows_per_chunk,output_folder):
-
+    """
+    Format a CDM model by passing all CDM objects and applying formatting.
+    """
     types = list(set([
         os.path.splitext(fname)[1]
         for fname in inputs
@@ -489,12 +545,13 @@ def gui(ctx):
         break
         
     window.close()
-
     
 
 @click.group(help="Commands for using python configurations to run the ETL transformation.")
 def py():
     pass
+
+
 
 py.add_command(make_class,"make")
 py.add_command(register_class,"register")
@@ -504,5 +561,6 @@ py.add_command(run_pyconfig,"run")
 map.add_command(py,"py")
 map.add_command(run,"run")
 map.add_command(format,"format")
+map.add_command(transform,"transform")
 map.add_command(gui,"gui")
 map.add_command(test,"test")

--- a/coconnect/cli/subcommands/map.py
+++ b/coconnect/cli/subcommands/map.py
@@ -74,6 +74,33 @@ def test(ctx):
 
 
 @click.command()
+@click.argument("inputs",nargs=-1)
+def format(inputs):
+
+    types = list(set([
+        os.path.splitext(fname)[1]
+        for fname in inputs
+    ]))
+    if len(types) > 1:
+        raise Exception(f"Running with mixed input files '{types}'. Only input tsv or csv files.")
+    types = types[0]
+    
+    inputs = {
+        os.path.basename(x):x
+        for x in inputs
+    }
+    if types == '.csv':
+        inputs = tools.load_csv(inputs)
+    else:
+        inputs = tools.load_tsv(inputs)
+
+
+    cdm = coconnect.cdm.CommonDataModel()
+    print (cdm)
+
+    
+        
+@click.command()
 @click.option("--input",
               required=True,
               help='input csv file')
@@ -83,7 +110,7 @@ def test(ctx):
 @click.option("--operation",
               required=True,
               help="which operation to apply to the column")
-def format(column,operation,input):
+def format_input_data(column,operation,input):
     """
     Useful formatting command for applying an operation on some data before being passed into the ETL-Tool
 

--- a/coconnect/cli/subcommands/map.py
+++ b/coconnect/cli/subcommands/map.py
@@ -73,8 +73,10 @@ def test(ctx):
 
 
 @click.command()
-@click.argument("inputs",nargs=-1)
-def format(inputs):
+@click.option("--number-of-rows-per-chunk","--nc",default=1e5,type=int)
+@click.option("--output-folder","-o",required=True,type=str)
+@click.argument("inputs",nargs=-1,required=True)
+def format(inputs,number_of_rows_per_chunk,output_folder):
 
     types = list(set([
         os.path.splitext(fname)[1]
@@ -89,11 +91,14 @@ def format(inputs):
         for x in inputs
     }
     if types == '.csv':
-        inputs = tools.load_csv(inputs)
+        inputs = tools.load_csv(inputs,chunksize=number_of_rows_per_chunk)
     else:
-        inputs = tools.load_tsv(inputs)
+        inputs = tools.load_tsv(inputs,chunksize=number_of_rows_per_chunk)
 
-    cdm = coconnect.cdm.CommonDataModel.load(inputs=inputs,do_formatting=False)
+    cdm = coconnect.cdm.CommonDataModel.from_existing(inputs=inputs,
+                                                      output_folder=output_folder,
+                                                      format_level=1)
+    #cdm.save_files = False
     cdm.process()
         
 @click.command()

--- a/coconnect/cli/subcommands/map.py
+++ b/coconnect/cli/subcommands/map.py
@@ -13,7 +13,6 @@ def map():
     pass
 
 
-
 @click.command(help="Generate a python class from the OMOP mapping json")
 @click.option("--name",
               help="give the name of the dataset, this will be the name of the .py class file created")
@@ -94,8 +93,7 @@ def format(inputs):
     else:
         inputs = tools.load_tsv(inputs)
 
-
-    cdm = coconnect.cdm.CommonDataModel.load(inputs=inputs)
+    cdm = coconnect.cdm.CommonDataModel.load(inputs=inputs,do_formatting=False)
     cdm.process()
         
 @click.command()

--- a/coconnect/cli/subcommands/map.py
+++ b/coconnect/cli/subcommands/map.py
@@ -71,7 +71,35 @@ def test(ctx):
     ctx.invoke(run,inputs=inputs,rules=rules,output_folder=output_folder)
     for fname in glob.glob(f"{output_folder}{os.path.sep}*.tsv"):
         tools.diff_csv(fname,fname)
-          
+
+
+@click.command()
+@click.option("--input",
+              required=True,
+              help='input csv file')
+@click.option("--column",
+              required=True,
+              help="which column of the input data to modify")
+@click.option("--operation",
+              required=True,
+              help="which operation to apply to the column")
+def format(column,operation,input):
+    """
+    Useful formatting command for applying an operation on some data before being passed into the ETL-Tool
+
+    """
+    optools = coconnect.cdm.OperationTools()
+    allowed_operations = optools.keys()
+    if operation not in allowed_operations:
+        raise Exception(f"Operation '{operation}' is not a known operation. Choose from {allowed_operations}")
+    df_input = pd.read_csv(input)
+    df_input[column] = optools[operation](df_input[column])
+    n = 5 if len(df_input) > 5 else len(df_input)
+    print (df_input[column].sample(n))
+    df_input.to_csv(input)
+    
+    
+        
 @click.command()
 @click.option("--rules",
               required=True,
@@ -447,5 +475,6 @@ py.add_command(remove_class,"remove")
 py.add_command(run_pyconfig,"run")
 map.add_command(py,"py")
 map.add_command(run,"run")
+map.add_command(format,"format")
 map.add_command(gui,"gui")
 map.add_command(test,"test")

--- a/coconnect/tools/__init__.py
+++ b/coconnect/tools/__init__.py
@@ -15,6 +15,7 @@ from .file_helpers import (
     load_json,
     load_json_delta,
     load_csv,
+    load_tsv,
     InputData,
     remove_missing_sources_from_rules,
     filter_rules_by_destination_tables,

--- a/coconnect/tools/file_helpers.py
+++ b/coconnect/tools/file_helpers.py
@@ -202,6 +202,7 @@ def load_csv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",r
                          usecols=fields)
 
         df.attrs = {'original_file':load_path+fname}
+
         
         if isinstance(df,pd.DataFrame):
             #this should be removed

--- a/coconnect/tools/file_helpers.py
+++ b/coconnect/tools/file_helpers.py
@@ -29,6 +29,11 @@ class InputData:
             key:self[key]
             for key in self.keys()
         }
+
+    def __iter__(self):
+        return iter(self.__file_readers)
+    
+    #def __next__(self)
         
     def keys(self):
         return self.__file_readers.keys()

--- a/coconnect/tools/file_helpers.py
+++ b/coconnect/tools/file_helpers.py
@@ -33,8 +33,6 @@ class InputData:
     def __iter__(self):
         return iter(self.__file_readers)
     
-    #def __next__(self)
-        
     def keys(self):
         return self.__file_readers.keys()
 

--- a/coconnect/tools/file_helpers.py
+++ b/coconnect/tools/file_helpers.py
@@ -140,7 +140,6 @@ def load_csv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",r
             x:x
             for x in _map
         }
-
     
     logger = Logger("coconnect.tools.load_csv")
 
@@ -207,6 +206,11 @@ def load_csv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",r
         retval[key] = df
 
     return retval
+
+def load_tsv(_map,chunksize=None,nrows=None,lower_col_names=False,load_path="",rules=None):
+    sep="\t"
+    return load_csv(_map,sep=sep,chunksize=chunksize,nrows=nrows,
+                    lower_col_names=lower_col_names,load_path=load_path,rules=rules)
 
 
 def get_subfolders(input_folder):


### PR DESCRIPTION
This is a new command which is useful when playing with synthetic data.

A lot of the scan reports that we have access to might have been generated on datasets that did not comply with the data-standards, and therefore it can be useful to apply "operations on these"

Example - EAVE-II - the 'ageYear' column, used for mapping the birthdate is a Year rather that a Timestamp, therefore instead of using the field "operations" in the `json` file, we can use this CLI function to convert the column from a year to a Timestamp