### PR TITLE
Make the CI fail on Unix when raising an exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,7 @@ jobs:
       - run: |
           for filename in tests/*.tsv; do
                fname=${filename##*/}
-               if [[ -z $(coconnect display diff $filename coconnect/data/test/expected_outputs/$fname) ]];
-               then
-                  echo "$fname is good"
-               else
-                  echo "$fname failed!"
-                  coconnect display diff $filename coconnect/data/test/expected_outputs/$fname
-                  exit
-               fi
+               coconnect display diff $filename coconnect/data/test/expected_outputs/$fname
           done
 
       - uses: actions/upload-artifact@v2

--- a/coconnect/tools/file_helpers.py
+++ b/coconnect/tools/file_helpers.py
@@ -8,6 +8,8 @@ class MissingInputFiles(Exception):
     pass
 class DifferingColumns(Exception):
     pass
+class DifferingRows(Exception):
+    pass
 
 
 class InputData:
@@ -228,7 +230,7 @@ def diff_csv(file1,file2,separator=None,nrows=None):
         m = m.rename(columns={'_merge':'Only Contained Within'})
         m.index.name = 'Row Number'
         logger.error(m.reset_index().to_dict(orient='records'))
-        raise Exception("differences detected")
+        raise DifferingRows("Something not right with the rows, changes detected.")
         
     elif len(df1.columns) != len(df2.columns):
         


### PR DESCRIPTION
The CI wasn't failing (for Unix) when there were changes in the expected outputs.

Check commands now raise exceptions so no need for the bash if statement in the CI workflow 