### PR TITLE
Fixes for generating synthetic data

### DIFF
--- a/coconnect/cli/subcommands/generate.py
+++ b/coconnect/cli/subcommands/generate.py
@@ -30,6 +30,9 @@ def synthetic():
 def ccom(report_id,number_of_events,output_directory,
          fill_column_with_values,token,
          url):
+
+    fill_column_with_values = list(fill_column_with_values)
+    
     token = os.environ.get("COCONNECT_TOKEN") or token
     if token == None:
         raise MissingToken("you must use the option --token or set the environment variable COCONNECT_TOKEN to be able to use this functionality. I.e  export COCONNECT_TOKEN=12345678 ")
@@ -52,12 +55,21 @@ def ccom(report_id,number_of_events,output_directory,
     else:
         print (json.dumps(response.json(),indent=6))
         
-    tables = {
-        table['name']:table['id']
-        for table in response.json()
-        }
+    for table in response.json():
+        name = table['name']
+        _id = table['id']
 
-    for name,_id in tables.items():
+        #get which is the person_id and automatically fill this with incrementing values
+        #so they are not all NaN in the synthetic data (because of List Truncated...)
+        person_id = table['person_id']
+        _url = f"{url}/api/scanreportfieldsfilter/?id={person_id}&fields=name"
+        person_id = requests.get(
+            _url, headers=headers,
+            allow_redirects=True,
+        ).json()[0]['name'].lstrip('\ufeff')
+
+        fill_column_with_values.append(person_id)
+        
         _url = f"{url}/api/scanreportvaluesfilterscanreporttable/?scan_report_table={_id}&fields=value,frequency,scan_report_field"
         response = requests.get(
             _url, headers=headers,
@@ -85,8 +97,19 @@ def ccom(report_id,number_of_events,output_directory,
             if col_name == '': continue
             
             _df = df.loc[[col_name]]
+            _df['value'].replace('',np.nan,inplace=True)
+
+            _df = _df.dropna()
+            
+            
+            if len(_df) > number_of_events:
+                _df = _df.sample(frac=1)[:number_of_events]
+
+            
             frequency = _df['frequency']
             total = frequency.sum()
+
+            
             if total > 0 :
                 frequency = number_of_events*frequency / total
                 frequency = frequency.astype(int)
@@ -96,6 +119,7 @@ def ccom(report_id,number_of_events,output_directory,
             values = _df['value'].repeat(frequency)\
                                  .sample(frac=1)\
                                  .reset_index(drop=True)
+
             values.name = col_name
             df_synthetic[col_name] = values
 


### PR DESCRIPTION
When generating synthetic data within co-connect-tools from CCOM, we can look up what has been marked as the `person_id` in the table to help fill IDs in the synthetic dataset (usually these are Null/ List Truncated)

* automatically fill person_ids
* fix for null fields in the scan report