### PR TITLE
Add support for table "device_exposure"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ airflow*
 .python-version
 workflows
 .venv
-test_files

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ temp
 airflow*
 .python-version
 workflows
+.venv
+test_files

--- a/carrot/cdm/__init__.py
+++ b/carrot/cdm/__init__.py
@@ -3,14 +3,15 @@ from .operations import OperationTools
 
 from .objects import get_cdm_class, get_cdm_decorator
 
-#can we make these imports dynamic?
+# can we make these imports dynamic?
 from .objects import (
     Person,
     ConditionOccurrence,
     VisitOccurrence,
     Measurement,
     Observation,
-    DrugExposure
+    DrugExposure,
+    DeviceExposure,
 )
 
 from .decorators import (
@@ -21,7 +22,8 @@ from .decorators import (
     define_measurement,
     define_observation,
     define_drug_exposure,
+    define_device_exposure,
     load_file,
     from_table,
-    qsub
+    qsub,
 )

--- a/carrot/cdm/decorators.py
+++ b/carrot/cdm/decorators.py
@@ -1,4 +1,3 @@
-
 from .objects import (
     Person,
     ConditionOccurrence,
@@ -6,7 +5,8 @@ from .objects import (
     Measurement,
     Observation,
     DrugExposure,
-    Death
+    DeviceExposure,
+    Death,
 )
 import copy
 import sys
@@ -14,38 +14,40 @@ import time
 
 import subprocess
 
+
 class analysis(object):
     def __init__(self, method):
         self._method = method
         self._name = method.__name__
+
     def __call__(self, obj, *args, **kwargs):
         return self._method(obj, *args, **kwargs)
 
-       
+
 class qsub(object):
 
-    def __init__(self,jobscript,**kwargs):
+    def __init__(self, jobscript, **kwargs):
         self.default_kwargs = kwargs
         self.jobscript = jobscript
 
-    def set_jobscript(self,jobscript):
+    def set_jobscript(self, jobscript):
         self.jobscript = jobscript
-    
+
     def __call__(self, analysis, *args, **kwargs):
         return self._qsub(analysis, *args, **kwargs)
 
-    def make_jobscript(self,**kwargs):
+    def make_jobscript(self, **kwargs):
         return self.jobscript.format(**kwargs)
-    
+
     @classmethod
-    def eddie(cls,**kwargs):
-        default_kwargs={'runtime':"00:30:00",'memory':"1G",'anaconda':"5.3.1"}
+    def eddie(cls, **kwargs):
+        default_kwargs = {"runtime": "00:30:00", "memory": "1G", "anaconda": "5.3.1"}
         default_kwargs.update(kwargs)
-        jobscript = r'''
+        jobscript = r"""
 #!/bin/sh
 # Grid Engine options (lines prefixed with #$)
-#$ -N {job_name}             
-#$ -cwd                  
+#$ -N {job_name}
+#$ -cwd
 #$ -l h_rt={runtime}
 #$ -l h_vmem={memory}
 
@@ -60,46 +62,53 @@ source /exports/applications/apps/SL7/anaconda/5.3.1/etc/profile.d/conda.sh
 conda activate carrot-env
 
 {command}
-'''
-        obj = cls(jobscript=jobscript,**default_kwargs)
-        
+"""
+        obj = cls(jobscript=jobscript, **default_kwargs)
+
         return obj
 
-    def run(self,commands,jobname="qsub_job"):
+    def run(self, commands, jobname="qsub_job"):
         kwargs = self.default_kwargs
-        kwargs.update({'job_name':jobname,'command':" ".join(commands)})
+        kwargs.update({"job_name": jobname, "command": " ".join(commands)})
         jobscript = self.make_jobscript(**kwargs)
         fname = f"{jobname}.sh"
-        with open(fname,"w") as f:
+        with open(fname, "w") as f:
             f.write(jobscript)
-        output = subprocess.check_output(['qsub','-N',jobname,fname]).decode()
+        output = subprocess.check_output(["qsub", "-N", jobname, fname]).decode()
         return output
 
-    def _qsub(self,analysis,*args,**kwargs):        
-        def wrapper(model,*args,**kwargs):
+    def _qsub(self, analysis, *args, **kwargs):
+        def wrapper(model, *args, **kwargs):
             commands = copy.copy(sys.argv)
             if "--analysis" in commands:
-                return analysis(model,*args,**kwargs)
+                return analysis(model, *args, **kwargs)
             else:
-                commands.extend(["--analysis",analysis.__name__])
+                commands.extend(["--analysis", analysis.__name__])
                 name = "analysis"
-                _id = format(id(analysis),'X')
-                return self.run(commands=commands,jobname=f"{name}_{analysis.__name__}_{_id}")
+                _id = format(id(analysis), "X")
+                return self.run(
+                    commands=commands, jobname=f"{name}_{analysis.__name__}_{_id}"
+                )
+
         return wrapper
-    #return _qsub
+
+    # return _qsub
+
 
 def load_file(_input):
     def func(self):
         for colname in _input:
             self[colname].series = _input[colname]
+
     return func
 
 
-def from_table(obj,table):
+def from_table(obj, table):
     df = obj.inputs[table]
     for colname in df.columns:
         obj[colname].series = df[colname]
     return obj
+
 
 def define_table(cls):
     def decorator(defs):
@@ -107,7 +116,9 @@ def define_table(cls):
         obj.define = defs
         obj.set_name(defs.__name__)
         return obj
+
     return decorator
+
 
 def define_person(defs):
     c = Person()
@@ -115,11 +126,13 @@ def define_person(defs):
     c.set_name(defs.__name__)
     return c
 
+
 def define_condition_occurrence(defs):
     c = ConditionOccurrence()
     c.define = defs
     c.set_name(defs.__name__)
     return c
+
 
 def define_visit_occurrence(defs):
     c = VisitOccurrence()
@@ -127,11 +140,13 @@ def define_visit_occurrence(defs):
     c.set_name(defs.__name__)
     return c
 
+
 def define_measurement(defs):
     c = Measurement()
     c.define = defs
     c.set_name(defs.__name__)
     return c
+
 
 def define_observation(defs):
     c = Observation()
@@ -139,15 +154,23 @@ def define_observation(defs):
     c.set_name(defs.__name__)
     return c
 
+
 def define_drug_exposure(defs):
     c = DrugExposure()
     c.define = defs
     c.set_name(defs.__name__)
     return c
 
+
+def define_device_exposure(defs):
+    c = DeviceExposure()
+    c.define = defs
+    c.set_name(defs.__name__)
+    return c
+
+
 def define_death(defs):
     c = Death()
     c.define = defs
     c.set_name(defs.__name__)
     return c
-

--- a/carrot/cdm/objects/versions/v5_3_1/__init__.py
+++ b/carrot/cdm/objects/versions/v5_3_1/__init__.py
@@ -7,4 +7,4 @@ from .procedure_occurrence import ProcedureOccurrence
 from .specimen import Specimen
 from .visit_occurrence import VisitOccurrence
 from .death import Death
-
+from .device_exposure import DeviceExposure

--- a/carrot/cdm/objects/versions/v5_3_1/device_exposure.py
+++ b/carrot/cdm/objects/versions/v5_3_1/device_exposure.py
@@ -1,0 +1,68 @@
+import pandas as pd
+from ...common import DestinationTable, DestinationField
+
+
+class DeviceExposure(DestinationTable):
+    """
+    CDM Device Exposure object class
+    """
+
+    name = "device_exposure"
+
+    def __init__(self, name=None):
+        self.device_exposure_id = DestinationField(
+            dtype="Integer", required=True, pk=True
+        )
+        self.person_id = DestinationField(dtype="Integer", required=True)
+        self.device_concept_id = DestinationField(dtype="Integer", required=True)
+        # Q: Does this "required" param reflect the same param on OMOP CDM?
+        self.device_exposure_start_date = DestinationField(dtype="Date", required=False)
+        self.device_exposure_start_datetime = DestinationField(
+            dtype="Timestamp", required=True
+        )
+        self.device_exposure_end_date = DestinationField(dtype="Date", required=False)
+        self.device_exposure_end_datetime = DestinationField(
+            dtype="Timestamp", required=False
+        )
+        self.device_type_concept_id = DestinationField(dtype="Integer", required=False)
+        self.quantity = DestinationField(dtype="Integer", required=False)
+        self.provider_id = DestinationField(dtype="Integer", required=False)
+        self.visit_occurrence_id = DestinationField(dtype="Integer", required=False)
+        self.visit_detail_id = DestinationField(dtype="Integer", required=False)
+        self.unique_device_id = DestinationField(dtype="Text255", required=False)
+        self.production_id = DestinationField(dtype="Text255", required=False)
+        self.device_source_value = DestinationField(dtype="Text50", required=False)
+        self.device_source_concept_id = DestinationField(
+            dtype="Integer", required=False
+        )
+        self.unit_concept_id = DestinationField(dtype="Integer", required=False)
+        self.unit_source_value = DestinationField(dtype="Text50", required=False)
+        self.unit_source_concept_id = DestinationField(dtype="Integer", required=False)
+
+        if name is None:
+            name = hex(id(self))
+        super().__init__(name, self.name)
+
+    def get_df(self, **kwargs):
+        """
+        Overload/append the creation of the dataframe, specifically for the device_exposure objects
+        * device_concept_id  is required to be not null
+          this can happen when spawning multiple rows from a person
+          we just want to keep the ones that have actually been filled
+
+        Returns:
+           pandas.Dataframe: output dataframe
+        """
+
+        df = super().get_df(**kwargs)
+        if self.automatically_fill_missing_columns == True:
+            if df["device_exposure_start_date"].isnull().all():
+                df["device_exposure_start_date"] = self.tools.get_date(
+                    df["device_exposure_start_datetime"]
+                )
+
+            if df["device_exposure_end_date"].isnull().all():
+                df["device_exposure_end_date"] = self.tools.get_date(
+                    df["device_exposure_end_datetime"]
+                )
+        return df

--- a/carrot/config/omop.json
+++ b/carrot/config/omop.json
@@ -1,46 +1,51 @@
 {
   "datetime_linked_fields": {
     "condition_occurrence": {
-	    "condition_start_datetime": "condition_start_date", 
-	    "condition_end_datetime": "condition_end_date"
+      "condition_start_datetime": "condition_start_date",
+      "condition_end_datetime": "condition_end_date"
     },
     "death": {
-	    "death_datetime": "death_date"
+      "death_datetime": "death_date"
     },
     "drug_exposure": {
-	    "drug_exposure_start_datetime": "drug_exposure_start_date", 
-	    "drug_exposure_end_datetime": "drug_exposure_end_date"
+      "drug_exposure_start_datetime": "drug_exposure_start_date",
+      "drug_exposure_end_datetime": "drug_exposure_end_date"
+    },
+    "device_exposure": {
+      "device_exposure_start_datetime": "device_exposure_start_date",
+      "device_exposure_end_datetime": "device_exposure_end_date"
     },
     "measurement": {
-	    "measurement_datetime": "measurement_date"
+      "measurement_datetime": "measurement_date"
     },
     "observation": {
-	    "observation_datetime": "observation_date"
+      "observation_datetime": "observation_date"
     },
     "procedure_occurrence": {
-	    "procedure_datetime": "procedure_date"
+      "procedure_datetime": "procedure_date"
     },
     "specimen": {
-	    "specimen_datetime": "specimen_date"
+      "specimen_datetime": "specimen_date"
     },
     "visit_occurrence": {
-	    "visit_start_datetime": "visit_start_date", 
-	    "visit_end_datetime": "visit_end_date"
+      "visit_start_datetime": "visit_start_date",
+      "visit_end_datetime": "visit_end_date"
     }
   },
   "date_field_components": {
     "person": {
-	    "birth_datetime": {
-		    "year":"year_of_birth", 
-		    "month":"month_of_birth", 
-		    "day":"day_of_birth"
-	    }
+      "birth_datetime": {
+        "year": "year_of_birth",
+        "month": "month_of_birth",
+        "day": "day_of_birth"
+      }
     }
   },
   "person_id_field": {
     "condition_occurrence": "person_id",
     "death": "person_id",
     "drug_exposure": "person_id",
+    "device_exposure": "person_id",
     "measurement": "person_id",
     "observation": "person_id",
     "person": "person_id",
@@ -52,6 +57,7 @@
     "condition_occurrence": "condition_occurrence_id",
     "death": "death_id",
     "drug_exposure": "drug_exposure_id",
+    "device_exposure": "device_exposure_id",
     "measurement": "measurement_id",
     "observation": "observation_id",
     "procedure_occurrence": "procedure_occurrence_id",

--- a/carrot/tools/extract/templates.py
+++ b/carrot/tools/extract/templates.py
@@ -1,6 +1,7 @@
 from jinja2 import Template
 
-cls = Template(r'''from carrot.cdm import define_person, define_condition_occurrence, define_visit_occurrence, define_measurement, define_observation, define_drug_exposure
+cls = Template(
+    r"""from carrot.cdm import define_person, define_condition_occurrence, define_visit_occurrence, define_measurement, define_observation, define_device_exposure, define_drug_exposure
 from carrot.cdm import CommonDataModel
 import json
 
@@ -13,30 +14,38 @@ class {{ name }}(CommonDataModel):
 if __name__ == '__main__':
     {{ name }}()
 
-''')
+"""
+)
 
-init = Template(r'''
+init = Template(
+    r'''
     def __init__(self,**kwargs):
-        """ 
-        initialise the inputs and setup indexing 
+        """
+        initialise the inputs and setup indexing
         """
         super().__init__(**kwargs)
         {% if person_ids %}
         #set primary key indexing so tables can be linked
         self.set_indexing({{ person_ids }})
         {% endif %}
-''')
-
 '''
+)
+
+"""
 {% for ds,pk in person_ids.items() -%}
         self.inputs["{{ ds }}"].index = self.inputs["{{ ds }}"]["{{ pk }}"].rename('index')
-        {% endfor %} 
-'''
+        {% endfor %}
+"""
 
-rule = Template(r'''self.{{ destination_field }}.series = self.inputs["{{ source_table }}"]["{{ source_field }}"]''')
-operation = Template(r'''self.{{ destination_field }}.series = self.tools.{{ operation }}(self.{{ destination_field }}.series)''')
+rule = Template(
+    r"""self.{{ destination_field }}.series = self.inputs["{{ source_table }}"]["{{ source_field }}"]"""
+)
+operation = Template(
+    r"""self.{{ destination_field }}.series = self.tools.{{ operation }}(self.{{ destination_field }}.series)"""
+)
 
-obj = Template(r'''
+obj = Template(
+    r'''
     @define_{{ object_name }}
     def {{ function_name }}(self):
         """
@@ -45,5 +54,5 @@ obj = Template(r'''
         {% for rule in map_rules -%}
         {{ rule }}
         {% endfor %}
-''')
-
+'''
+)


### PR DESCRIPTION
Dear maintainers of the Carrot CDM repo,

I am Thien, a software engineer from the University of Nottingham who has been working on [Carrot Mapper](https://github.com/Health-Informatics-UoN/Carrot-Mapper) since April 2024.  

For the context of this PR, we received a [feature request](https://github.com/Health-Informatics-UoN/Carrot-Mapper/issues/636) to expand Carrot mapper's ability to add concepts having the domain ["Device"](https://athena.ohdsi.org/search-terms/terms?domain=Device&page=1&pageSize=15&query=). We have fulfilled this request on Carrot mapper by [this PR ](https://github.com/Health-Informatics-UoN/Carrot-Mapper/pull/886), but we thought that it would not be enough if Carrot CDM doesn't support the conversion for the OMOP table "device_exposure" or the Mapping JSON related to "device_exposure".

About the PR itself, following the existing workflow and procedure of defining and applying an object/OMOP table, the support for "device_exposure" table has been added. Please don't mind the automatic formatting edits. 

Please have a look and I am happy to answer any questions.

Thanks!  